### PR TITLE
Fix HyperConnections device selection

### DIFF
--- a/model_architecture.py
+++ b/model_architecture.py
@@ -172,19 +172,19 @@ class HyperConnections(nn.Module):
         self.expansion_rate = expansion_rate
         
         # Determinar si CUDA está disponible
-        device = torch.device('cuda')
-        
-        # Definición de las matrices estáticas - directamente en CUDA con bfloat16
+        device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+
+        # Definición de las matrices estáticas con soporte para CPU o GPU
         self.static_beta = nn.Parameter(torch.ones(expansion_rate, device=device, dtype=torch.bfloat16))
         
-        # Inicialización de alpha según el paper - directamente en CUDA con bfloat16
+        # Inicialización de alpha según el paper en bfloat16
         init_alpha0 = torch.zeros((expansion_rate, 1), device=device, dtype=torch.bfloat16)
         init_alpha0[depth % expansion_rate, 0] = 1.
         
         self.static_alpha = nn.Parameter(torch.cat(
             [init_alpha0, torch.eye(expansion_rate, device=device, dtype=torch.bfloat16)], dim=1))
         
-        # Parámetros para la parte dinámica - directamente en CUDA con bfloat16
+        # Parámetros para la parte dinámica en bfloat16
         self.dynamic_alpha_fn = nn.Parameter(torch.zeros((d_model, expansion_rate+1), device=device, dtype=torch.bfloat16))
         self.dynamic_alpha_scale = nn.Parameter(torch.ones(1, device=device, dtype=torch.bfloat16) * 0.01)
         self.dynamic_beta_fn = nn.Parameter(torch.zeros((d_model), device=device, dtype=torch.bfloat16))


### PR DESCRIPTION
## Summary
- ensure HyperConnections initializes tensors on CPU when CUDA is unavailable

## Testing
- `python -m py_compile model_architecture.py`


------
https://chatgpt.com/codex/tasks/task_e_6895765e2bc083279b254d3e105b9084